### PR TITLE
Add wildcard ability for htaccess filename checking

### DIFF
--- a/WSC/handlers.js
+++ b/WSC/handlers.js
@@ -516,7 +516,7 @@ class DirectoryEntryHandler {
         }
         if (this.opts.excludeDotHtml && !this.request.origpath.endsWith("/") && this.request.path !== '') {
             const extension = this.request.path.split('.').pop();
-            const more = this.request.uri.substring(0, this.request.path.origpath);
+            const more = this.request.uri.substring(this.request.origpath.length);
             if (['htm', 'html'].includes(extension)) {
                 const path = this.request.path;
                 let newpath;

--- a/WSC/utils.js
+++ b/WSC/utils.js
@@ -82,6 +82,14 @@ module.exports = {
         if (origpath === '/') return '/';
         return origpath.substring(0, origpath.length - origpath.split('/').pop().length);
     },
+    isExpectedFile: function(file, expected) {
+        if (expected === "all files") return true;
+        if (!expected.includes("*")) return (file === expected);
+        if (expected === "*") return true;
+        if (expected.startsWith("*.") && file.split(expected.substring(1)).pop() === "") return true;
+        if (expected.endsWith(".*") && file.split(expected.substring(0, expected.length-1))[0] === "") return true;
+        return (file === expected);
+    },
     isHidden: function(path) {
         //RegExp from https://stackoverflow.com/questions/18973655/how-to-ignore-hidden-files-in-fs-readdir-result/37030655#37030655
         const a = path.split('/');


### PR DESCRIPTION
if the requested file is `abc.html` and the server is told to do something at `*.html`, it will do it.
if the requested file is `abc.html` and the server is told to do something at `abc.*`, it will do it.
if the requested file is `abc.html` and the server is told to do something at `*`, it will do it.

Also fixes a small (major) bug with the redirection using the no .html extension option

The htaccess feature is pretty much done - just needs some documentation behind it

ps: (unrelated note) sorry for any immaturity I've shown when working in the past. Ive been working quite a bit and am really confident in my coding now.