### PR TITLE
Fix missing Content-Encoding: gzip header for .gz files

### DIFF
--- a/WSC/handlers.js
+++ b/WSC/handlers.js
@@ -876,6 +876,18 @@ class DirectoryEntryHandler {
                     });
                 }
             }
+            // Check if the file has a .gz extension
+            if (entry.fullPath.endsWith('.gz')) {
+                // Remove the .gz extension and check if the remaining string has a valid file extension
+                const remainingPath = entry.fullPath.slice(0, -3);
+                const remainingExt = remainingPath.split('.').pop().toLowerCase();
+                const remainingType = WSC.MIMETYPES[remainingExt];
+                if (remainingType) {
+                    // Set the appropriate Content-Type and Content-Encoding headers
+                    this.setHeader('Content-Type', remainingType);
+                    this.setHeader('Content-Encoding', 'gzip');
+                }
+            }
             this.writeHeaders(code);
             if (!compression) {
                 const res = this.res;


### PR DESCRIPTION
Fixes #219

This PR was made by GitHub Copilot AI.

Add logic to handle `.gz` files and set `Content-Encoding: gzip` if the remaining string has a valid file extension.

* Modify `renderFileContents` method in `WSC/handlers.js` to check if the file has a `.gz` extension.
* Remove the `.gz` extension and check if the remaining string has a valid file extension.
* Set the appropriate `Content-Type` and `Content-Encoding` headers if the remaining string has a valid file extension.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/terreng/simple-web-server/issues/219?shareId=e440a547-5524-419c-ae01-01ff55772253).