### PR TITLE
Issue 260: Update subjectAltName for reduced security warnings

### DIFF
--- a/WSC/crypto.js
+++ b/WSC/crypto.js
@@ -44,7 +44,10 @@ module.exports = function() {
         name: 'subjectAltName',
         altNames: [{
             type: 6, // URI
-            value: 'http://localhost'
+            value: 'https://localhost'
+        }, {
+            type: 7, // IP
+            ip: '127.0.0.1'
         }]
     }]);
     // FIXME: add subjectKeyIdentifier extension


### PR DESCRIPTION
Corrected subjectAltName code in wsc\crypto.js, to specify a URI of https://localhost rather than http://localhost, and to also specify an IP of the IPv4 loopback address.